### PR TITLE
Add no wrap flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,8 @@ pub enum Command {
 pub struct CommandNext {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "disable wrapping around workspaces")]
+    pub no_wrap: bool,
 }
 
 /// Focus on the previous window. If the current window is already at the edge, focus on the previous workspace.
@@ -28,5 +30,6 @@ pub struct CommandNext {
 pub struct CommandPrev {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "disable wrapping around workspaces")]
+    pub no_wrap: bool,
 }
-


### PR DESCRIPTION
# Feature
Added a no-wrap flag to disable default wrapping behavior.

# Implementation
Add a helper function to determine whether the navigation direction will cause a wrap from the min client to the max client, and vice versa.
Add a guard clause to return early in such a case when the flag is present, otherwise not affecting the control flow.

# Testing
Did some testing on my own machine with `swap` enabled and disabled.