### PR TITLE
Add a move-window flag and handler

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,8 @@ pub enum Command {
 pub struct CommandNext {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "move window")]
+    pub move_window: bool,
 }
 
 /// Focus on the previous window. If the current window is already at the edge, focus on the previous workspace.
@@ -28,5 +30,6 @@ pub struct CommandNext {
 pub struct CommandPrev {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "move window")]
+    pub move_window: bool,
 }
-

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,8 @@ pub enum Command {
 pub struct CommandNext {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "disable wrapping around workspaces")]
+    pub no_wrap: bool,
 }
 
 /// Focus on the previous window. If the current window is already at the edge, focus on the previous workspace.
@@ -28,5 +30,6 @@ pub struct CommandNext {
 pub struct CommandPrev {
     #[argh(switch, description = "swap window")]
     pub swap: bool,
+    #[argh(switch, description = "disable wrapping around workspaces")]
+    pub no_wrap: bool,
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use std::cmp;
 
 use hyprland::{
     data::{Client, Clients},
-    dispatch::{Direction, Dispatch, DispatchType, WindowIdentifier, WorkspaceIdentifierWithSpecial},
+    dispatch::{
+        Direction, Dispatch, DispatchType, WindowIdentifier, WindowMove,
+        WorkspaceIdentifierWithSpecial,
+    },
     shared::{HyprData, HyprDataActiveOptional, HyprDataVec},
 };
 
@@ -16,9 +19,7 @@ fn main() -> anyhow::Result<()> {
     let clients = Clients::get()?;
     assert!(clients.iter().len() > 1, "less than 2 clients");
 
-    let Some(act_client) = Client::get_active()
-        .ok()
-        .flatten() else {
+    let Some(act_client) = Client::get_active().ok().flatten() else {
         return handle_in_empty_ws(params);
     };
     let act_ws_id = act_client.workspace.id;
@@ -32,23 +33,21 @@ fn main() -> anyhow::Result<()> {
     use Command::*;
     match params.cmd {
         Next(params) => {
-            let next_left = get_bound_client(&clients, next_ws_id)
-                .map_or(first_client, |(c, _)| c);
+            let next_left = get_bound_client(&clients, next_ws_id).map_or(first_client, |(c, _)| c);
 
             if is_bound(&act_client, right, true) {
-                handle_bound_navigation(next_left, &act_client, params.swap)?;
+                handle_bound_navigation(next_left, &act_client, params.swap, params.move_window)?;
             } else {
-                handle_default_navigation(Direction::Right, params.swap)?;
+                handle_default_navigation(Direction::Right, params.swap, params.move_window)?;
             }
         }
         Prev(params) => {
-            let prev_right = get_bound_client(&clients, prev_ws_id)
-                .map_or(last_client, |(_, c)| c);
+            let prev_right = get_bound_client(&clients, prev_ws_id).map_or(last_client, |(_, c)| c);
 
             if is_bound(&act_client, left, false) {
-                handle_bound_navigation(prev_right, &act_client, params.swap)?;
+                handle_bound_navigation(prev_right, &act_client, params.swap, params.move_window)?;
             } else {
-                handle_default_navigation(Direction::Left, params.swap)?
+                handle_default_navigation(Direction::Left, params.swap, params.move_window)?
             };
         }
     };
@@ -67,9 +66,11 @@ fn handle_in_empty_ws(params: Flags) -> anyhow::Result<()> {
 }
 
 #[inline]
-fn handle_default_navigation(dir: Direction, swap: bool) -> anyhow::Result<()> {
+fn handle_default_navigation(dir: Direction, swap: bool, move_window: bool) -> anyhow::Result<()> {
     Dispatch::call(if swap {
         DispatchType::SwapWindow(dir)
+    } else if move_window {
+        DispatchType::MoveWindow(WindowMove::Direction(dir))
     } else {
         DispatchType::MoveFocus(dir)
     })?;
@@ -77,9 +78,25 @@ fn handle_default_navigation(dir: Direction, swap: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn handle_bound_navigation(client: &Client, act_client: &Client, swap: bool) -> anyhow::Result<()> {
+fn handle_move_window_to_ws(act_client: &Client, target_ws_id: i32) -> anyhow::Result<()> {
+    // Use non-silent move to workspace to move client and focus new workspace
+    Dispatch::call(DispatchType::MoveToWorkspace(
+        WorkspaceIdentifierWithSpecial::Id(target_ws_id),
+        Some(WindowIdentifier::Address(act_client.address.clone())),
+    ))?;
+    Ok(())
+}
+
+fn handle_bound_navigation(
+    client: &Client,
+    act_client: &Client,
+    swap: bool,
+    move_window: bool,
+) -> anyhow::Result<()> {
     if swap {
         handle_swap(client, act_client)
+    } else if move_window {
+        handle_move_window_to_ws(act_client, client.workspace.id)
     } else {
         handle_focus(client)
     }
@@ -87,26 +104,24 @@ fn handle_bound_navigation(client: &Client, act_client: &Client, swap: bool) -> 
 
 fn handle_swap(client: &Client, act_client: &Client) -> anyhow::Result<()> {
     // move current to target workspace
-    Dispatch::call(
-        DispatchType::MoveToWorkspaceSilent(
-            WorkspaceIdentifierWithSpecial::Id(client.workspace.id),
-            Some(WindowIdentifier::Address(act_client.address.clone()))
-        )
-    )?;
+    Dispatch::call(DispatchType::MoveToWorkspaceSilent(
+        WorkspaceIdentifierWithSpecial::Id(client.workspace.id),
+        Some(WindowIdentifier::Address(act_client.address.clone())),
+    ))?;
 
     // move target client to current workspace
-    Dispatch::call(
-        DispatchType::MoveToWorkspace(
-            WorkspaceIdentifierWithSpecial::Id(act_client.workspace.id),
-            Some(WindowIdentifier::Address(client.address.clone()))
-        )
-    )?;
+    Dispatch::call(DispatchType::MoveToWorkspace(
+        WorkspaceIdentifierWithSpecial::Id(act_client.workspace.id),
+        Some(WindowIdentifier::Address(client.address.clone())),
+    ))?;
 
     Ok(())
 }
 
 fn handle_focus(client: &Client) -> anyhow::Result<()> {
-    Dispatch::call(DispatchType::FocusWindow(WindowIdentifier::Address(client.address.clone())))?;
+    Dispatch::call(DispatchType::FocusWindow(WindowIdentifier::Address(
+        client.address.clone(),
+    )))?;
     Ok(())
 }
 
@@ -120,13 +135,26 @@ fn get_neighborhood_workspace(clients: &[Client], act_ws_id: i32) -> (i32, i32) 
 
     let (prev, next, max, min) = clients
         .iter()
-        .filter(|client| client.workspace.id != act_ws_id && !client.workspace.name.starts_with("special"))
-        .fold((act_ws_id, act_ws_id, act_ws_id, act_ws_id), |acc, client| {
-            let id = client.workspace.id;
-            let prev = if act_ws_id > id && near_than_last(id, acc.0) { id } else { acc.0 };
-            let next = if act_ws_id < id && near_than_last(id, acc.1) { id } else { acc.1 };
-            (prev, next, cmp::max(acc.2, id), cmp::min(acc.3, id))
-        });
+        .filter(|client| {
+            client.workspace.id != act_ws_id && !client.workspace.name.starts_with("special")
+        })
+        .fold(
+            (act_ws_id, act_ws_id, act_ws_id, act_ws_id),
+            |acc, client| {
+                let id = client.workspace.id;
+                let prev = if act_ws_id > id && near_than_last(id, acc.0) {
+                    id
+                } else {
+                    acc.0
+                };
+                let next = if act_ws_id < id && near_than_last(id, acc.1) {
+                    id
+                } else {
+                    acc.1
+                };
+                (prev, next, cmp::max(acc.2, id), cmp::min(acc.3, id))
+            },
+        );
 
     let prev = if prev == act_ws_id { max } else { prev };
     let next = if next == act_ws_id { min } else { next };
@@ -151,7 +179,9 @@ fn get_bound_client(clients: &[Client], workspace: i32) -> Option<(&Client, &Cli
 
     let result = clients
         .iter()
-        .filter(|client| client.workspace.id == workspace && !client.workspace.name.starts_with("special"))
+        .filter(|client| {
+            client.workspace.id == workspace && !client.workspace.name.starts_with("special")
+        })
         .fold((&clients[0], &clients[0]), |mut result, client| {
             if result.0.workspace.id != workspace {
                 result.0 = client;
@@ -177,9 +207,7 @@ fn get_bound_client(clients: &[Client], workspace: i32) -> Option<(&Client, &Cli
 
 #[inline]
 fn is_bound(act: &Client, right: &Client, side_right: bool) -> bool {
-    act.address == right.address || (
-        (side_right && act.at.0 + act.size.0 == right.at.0 + right.size.0) ||
-        act.at.0 == right.at.0
-    )
+    act.address == right.address
+        || ((side_right && act.at.0 + act.size.0 == right.at.0 + right.size.0)
+            || act.at.0 == right.at.0)
 }
-


### PR DESCRIPTION
# Behavior
Combines movewindow and movetoworkspace similarly to how hyprnavi combines changefocus and workspace.

# Implementation
Added handler for default navigation and boundary navigation.